### PR TITLE
Add libnvcomp and libnvjpeg2k0 as runtime deps

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,9 +11,11 @@ jobs:
       win_64_cuda_compiler_version12.9:
         CONFIG: win_64_cuda_compiler_version12.9
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_cuda_compiler_version13.0:
         CONFIG: win_64_cuda_compiler_version13.0
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,26 +23,31 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_cuda_compiler_version12.9
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_cuda_compiler_version13.0
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_arm_variant_typesbsacuda_compiler_version12.9
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_arm_variant_typesbsacuda_compiler_version13.0
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_arm_variant_typetegracuda_compiler_version12.9
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -119,7 +124,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,8 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-        - libnvcomp >=5,<6
+        # libnvcomp has no tegra build on conda-forge; DEFLATE codec won't be available on tegra
+        - libnvcomp >=5,<6  # [not (linux and aarch64 and arm_variant_type == "tegra")]
         # FIXME: nvjpeg2k is pre-1.0 and may break ABI across minors; revisit upper pin on each nvtiff update until nvjpeg2k >= 1.0
         - libnvjpeg2k0 >=0.8.1,<0.11
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,12 +45,12 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cuda") }}
         - {{ stdlib("c") }}
+        - arm-variant * {{ arm_variant_type }}  # [linux and aarch64]
       host:
         - cuda-version {{ cuda_compiler_version }}
-        - arm-variant * {{ arm_variant_type }}  # [linux and aarch64]
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-        - libnvcomp >=5
+        - libnvcomp >=5,<6
         - libnvjpeg2k0 >=0.8.1
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,8 @@ outputs:
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
         - libnvcomp >=5,<6
-        - libnvjpeg2k0 >=0.8.1
+        # FIXME: nvjpeg2k is pre-1.0 and may break ABI across minors; revisit upper pin on each nvtiff update until nvjpeg2k >= 1.0
+        - libnvjpeg2k0 >=0.8.1,<0.11
     test:
       commands:
         - test -L $PREFIX/lib/libnvtiff.so.{{ version.split(".")[0] }}                            # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ outputs:
         - cuda-version {{ cuda_compiler_version }}
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
-        # libnvcomp has no tegra build on conda-forge; DEFLATE codec won't be available on tegra
+        # nvcomp is not supported on Jetson/tegra platforms; DEFLATE codec is unavailable there
         - libnvcomp >=5,<6  # [not (linux and aarch64 and arm_variant_type == "tegra")]
         # FIXME: nvjpeg2k is pre-1.0 and may break ABI across minors; revisit upper pin on each nvtiff update until nvjpeg2k >= 1.0
         - libnvjpeg2k0 >=0.8.1,<0.11

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     sha256: "e3a58435c4fea02bdaf5c626087a520477253e8b0e8bdf098168b4a5a7451345"  # [linux and aarch64 and (cuda_compiler_version or "").startswith("12") and arm_variant_type == "tegra"]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or ppc64le or cuda_compiler_version in (None, "None")]
   # skip: true  # [arm_variant_type == "tegra" and cuda_compiler_version != "12.9"]
 
@@ -45,11 +45,13 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cuda") }}
         - {{ stdlib("c") }}
-        - arm-variant * {{ arm_variant_type }}  # [linux and aarch64]
       host:
         - cuda-version {{ cuda_compiler_version }}
+        - arm-variant * {{ arm_variant_type }}  # [linux and aarch64]
       run:
         - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
+        - libnvcomp >=5
+        - libnvjpeg2k0 >=0.8.1
     test:
       commands:
         - test -L $PREFIX/lib/libnvtiff.so.{{ version.split(".")[0] }}                            # [linux]


### PR DESCRIPTION
## Summary

- nvTIFF `dlopen`s `libnvcomp.so.5` and `libnvjpeg2k.so.0` at runtime to support DEFLATE and JPEG2000 TIFF compression respectively. Neither is an ELF `NEEDED` entry, so they were silently missing from the recipe — users would hit `NVTIFF_STATUS_NVCOMP_NOT_FOUND` / `NVTIFF_STATUS_NVJPEG2K_NOT_FOUND` unless another package happened to pull them in. Add them as hard `run:` deps on the `libnvtiff{MAJOR}` runtime output (`libnvcomp >=5`, `libnvjpeg2k0 >=0.8.1`).
- Harmonize `arm-variant * {{ arm_variant_type }}` placement: previously in `requirements.build` for the runtime output but in `requirements.host` for `-dev` and `-static`. Moved the runtime's entry to `host` so all three outputs match.
- Bumped `build.number` to 1.

## Test plan

- [ ] CI green after `@conda-forge-admin, please rerender`
- [ ] `conda install libnvtiff` pulls in `libnvcomp >=5` and `libnvjpeg2k0 >=0.8.1` transitively